### PR TITLE
Adding the implementation of the GitBOM concept

### DIFF
--- a/gcc-11.3.0/gcc/c-family/c-opts.c
+++ b/gcc-11.3.0/gcc/c-family/c-opts.c
@@ -1322,7 +1322,13 @@ c_common_finish (void)
 	}
     }
 
-  /* If the calculation of the GitBOM information is enabled, do it here.  */
+  /* If the calculation of the GitBOM information is enabled, do it here.
+     Also, determine the directory to store GitBOM files in this order of
+     precedence.
+	1. If GITBOM_DIR environment variable is set, use this location.
+	2. Use the directory name passed with -frecord-gitbom option.
+	3. Default is to write the GitBOM files in the same directory as the
+	   object file.  */
   if (flag_record_gitbom || str_record_gitbom
       || (getenv ("GITBOM_DIR") && strlen (getenv ("GITBOM_DIR")) > 0))
     {

--- a/gcc-11.3.0/gcc/common.opt
+++ b/gcc-11.3.0/gcc/common.opt
@@ -2325,6 +2325,15 @@ frecord-gcc-switches
 Common Var(flag_record_gcc_switches)
 Record gcc command line switches in the object file.
 
+frecord-gitbom
+Common Var(flag_record_gitbom)
+Record gitoid of an artifact in the object file and calculate GitBOM information.
+
+frecord-gitbom=
+Common RejectNegative Joined Var(str_record_gitbom)
+Record gitoid of an artifact in the object file and calculate GitBOM information. Store that
+information in the specified directory, unless GITBOM_DIR environment variable is set as well.
+
 freg-struct-return
 Common Var(flag_pcc_struct_return,0) Optimization
 Return small aggregates in registers.

--- a/gcc-11.3.0/gcc/config/elfos.h
+++ b/gcc-11.3.0/gcc/config/elfos.h
@@ -462,6 +462,11 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 #undef  TARGET_ASM_RECORD_GCC_SWITCHES
 #define TARGET_ASM_RECORD_GCC_SWITCHES elf_record_gcc_switches
 
+/* Allow the use of the -frecord-gitbom switch via the
+   elf_record_gitbom function defined in varasm.c.  */
+#undef  TARGET_ASM_RECORD_GITBOM
+#define TARGET_ASM_RECORD_GITBOM elf_record_gitbom
+
 /* A C statement (sans semicolon) to output to the stdio stream STREAM
    any text necessary for declaring the name of an external symbol
    named NAME which is referenced in this compilation but not defined.

--- a/gcc-11.3.0/gcc/doc/tm.texi
+++ b/gcc-11.3.0/gcc/doc/tm.texi
@@ -8120,6 +8120,24 @@ ELF implementation of the @code{TARGET_ASM_RECORD_GCC_SWITCHES} target
 hook.
 @end deftypevr
 
+@deftypefn {Target Hook} void TARGET_ASM_RECORD_GITBOM (void)
+Provides the target with the ability to record the gitoid of an
+artifact.
+
+By default this hook is set to NULL, but an example implementation is
+provided for ELF based targets.  Called @var{elf_record_gitbom},
+it records the gitoid as ASCII text inside a new, string mergeable
+section in the assembler output file.  The name of the new section is
+provided by the @code{TARGET_ASM_RECORD_GITBOM_SECTION} target
+hook.
+@end deftypefn
+
+@deftypevr {Target Hook} {const char *} TARGET_ASM_RECORD_GITBOM_SECTION
+This is the name of the section that will be created by the example
+ELF implementation of the @code{TARGET_ASM_RECORD_GITBOM} target
+hook.
+@end deftypevr
+
 @need 2000
 @node Data Output
 @subsection Output of Data

--- a/gcc-11.3.0/gcc/doc/tm.texi.in
+++ b/gcc-11.3.0/gcc/doc/tm.texi.in
@@ -5200,6 +5200,10 @@ It must not be modified by command-line option processing.
 
 @hook TARGET_ASM_RECORD_GCC_SWITCHES_SECTION
 
+@hook TARGET_ASM_RECORD_GITBOM
+
+@hook TARGET_ASM_RECORD_GITBOM_SECTION
+
 @need 2000
 @node Data Output
 @subsection Output of Data

--- a/gcc-11.3.0/gcc/gitbom.h
+++ b/gcc-11.3.0/gcc/gitbom.h
@@ -1,0 +1,4 @@
+#include <string>
+
+/* An example implementation for ELF targets.  Defined in varasm.c  */
+extern void elf_record_gitbom_write_gitoid (std::string);

--- a/gcc-11.3.0/gcc/opts.c
+++ b/gcc-11.3.0/gcc/opts.c
@@ -34,6 +34,7 @@ along with GCC; see the file COPYING3.  If not see
 #include "diagnostic-color.h"
 #include "version.h"
 #include "selftest.h"
+#include "cpplib.h"
 
 static void set_Wstrict_aliasing (struct gcc_options *opts, int onoff);
 
@@ -2320,6 +2321,12 @@ common_handle_option (struct gcc_options *opts,
 		      diagnostic_context *dc,
 		      void (*target_option_override_hook) (void))
 {
+  if (strcmp ("-frecord-gitbom", decoded->orig_option_with_args_text) == 0
+      || strncmp ("-frecord-gitbom=", decoded->orig_option_with_args_text,
+		  strlen ("-frecord-gitbom=")) == 0
+      || (getenv ("GITBOM_DIR") && strlen (getenv ("GITBOM_DIR")) > 0))
+    set_gitbom_enabled (true);
+
   size_t scode = decoded->opt_index;
   const char *arg = decoded->arg;
   HOST_WIDE_INT value = decoded->value;

--- a/gcc-11.3.0/gcc/target.def
+++ b/gcc-11.3.0/gcc/target.def
@@ -793,6 +793,30 @@ ELF implementation of the @code{TARGET_ASM_RECORD_GCC_SWITCHES} target\n\
 hook.",
  const char *, ".GCC.command.line")
 
+/* Output a record of the gitoid of an artifact.  */
+DEFHOOK
+(record_gitbom,
+ "Provides the target with the ability to record the gitoid of an\n\
+artifact.\n\
+\n\
+By default this hook is set to NULL, but an example implementation is\n\
+provided for ELF based targets.  Called @var{elf_record_gitbom},\n\
+it records the gitoid as ASCII text inside a new, string mergeable\n\
+section in the assembler output file.  The name of the new section is\n\
+provided by the @code{TARGET_ASM_RECORD_GITBOM_SECTION} target\n\
+hook.",
+ void, (void),
+ NULL)
+
+/* The name of the section that the example ELF implementation of
+   record_gitbom will use to store the information.  */
+DEFHOOKPOD
+(record_gitbom_section,
+ "This is the name of the section that will be created by the example\n\
+ELF implementation of the @code{TARGET_ASM_RECORD_GITBOM} target\n\
+hook.",
+ const char *, ".bom")
+
 /* Output the definition of a section anchor.  */
 DEFHOOK
 (output_anchor,

--- a/gcc-11.3.0/gcc/target.h
+++ b/gcc-11.3.0/gcc/target.h
@@ -89,6 +89,9 @@ extern unsigned HOST_WIDE_INT by_pieces_ninsns (unsigned HOST_WIDE_INT,
 /* An example implementation for ELF targets.  Defined in varasm.c  */
 extern void elf_record_gcc_switches (const char *);
 
+/* An example implementation for ELF targets.  Defined in varasm.c  */
+extern void elf_record_gitbom (void);
+
 /* Some places still assume that all pointer or address modes are the
    standard Pmode and ptr_mode.  These optimizations become invalid if
    the target actually supports multiple different modes.  For now,

--- a/gcc-11.3.0/gcc/testsuite/gcc.dg/env_var_record_gitbom.c
+++ b/gcc-11.3.0/gcc/testsuite/gcc.dg/env_var_record_gitbom.c
@@ -1,0 +1,20 @@
+/* Test whether .bom section is created when environment variable GITBOM_DIR
+   is set. Note that the GitBOM Document file is also created in
+   $GITBOM_DIR/.gitbom/objects/<dir>/ inside the gcc/testsuite/gcc directory,
+   where <dir> consists of the first two hex characters of the 40-character
+   gitoid of that file. The remaining 38 hex characters of that gitoid are
+   used as the name of that GitBOM Document file.  */
+
+/* { dg-set-compiler-env-var GITBOM_DIR "env_gitbom_dir" } */
+/* { dg-do compile } */
+
+#include "gitbom.h"
+
+int f()
+{
+  int var = 0;
+  return var;
+}
+
+/* { dg-final { scan-assembler "\t.section\t.bom" } } */
+/* { dg-final { scan-assembler "\t.ascii\t\"*\"" } } */

--- a/gcc-11.3.0/gcc/testsuite/gcc.dg/frecord-gitbom.c
+++ b/gcc-11.3.0/gcc/testsuite/gcc.dg/frecord-gitbom.c
@@ -1,0 +1,19 @@
+/* Test whether .bom section is created when -frecord-gitbom=<arg> option is passed.
+   Note that the GitBOM Document file is also created in <arg>/.gitbom/objects/<dir>/
+   inside the gcc/testsuite/gcc directory, where <dir> consists of the first two
+   hex characters of the 40-character gitoid of that file. The remaining 38 hex
+   characters of that gitoid are used as the name of that GitBOM Document file.  */
+
+/* { dg-do compile } */
+/* { dg-options "-frecord-gitbom=gitbomdir" } */
+
+#include "gitbom.h"
+
+int f()
+{
+  int var = 0;
+  return var;
+}
+
+/* { dg-final { scan-assembler "\t.section\t.bom" } } */
+/* { dg-final { scan-assembler "\t.ascii\t\"*\"" } } */

--- a/gcc-11.3.0/gcc/testsuite/gcc.dg/gitbom.c
+++ b/gcc-11.3.0/gcc/testsuite/gcc.dg/gitbom.c
@@ -1,0 +1,19 @@
+/* Test whether .bom section is created when -frecord-gitbom option is passed.
+   Note that the GitBOM Document file is also created in .gitbom/objects/<dir>/
+   inside the gcc/testsuite/gcc directory, where <dir> consists of the first two
+   hex characters of the 40-character gitoid of that file. The remaining 38 hex
+   characters of that gitoid are used as the name of that GitBOM Document file.  */
+
+/* { dg-do compile } */
+/* { dg-options "-frecord-gitbom" } */
+
+#include "gitbom.h"
+
+int f()
+{
+  int var = 0;
+  return var;
+}
+
+/* { dg-final { scan-assembler "\t.section\t.bom" } } */
+/* { dg-final { scan-assembler "\t.ascii\t\"*\"" } } */

--- a/gcc-11.3.0/gcc/testsuite/gcc.dg/gitbom.h
+++ b/gcc-11.3.0/gcc/testsuite/gcc.dg/gitbom.h
@@ -1,0 +1,1 @@
+extern int f ();

--- a/gcc-11.3.0/gcc/toplev.c
+++ b/gcc-11.3.0/gcc/toplev.c
@@ -743,6 +743,17 @@ init_asm_output (const char *name)
 		    "the current target");
 	}
 
+      if (flag_record_gitbom || str_record_gitbom
+          || (getenv ("GITBOM_DIR") && strlen (getenv ("GITBOM_DIR")) > 0))
+	{
+	  if (targetm.asm_out.record_gitbom)
+	      targetm.asm_out.record_gitbom ();
+	  else
+	    inform (UNKNOWN_LOCATION,
+		    "%<-frecord-gitbom%> is not supported by "
+		    "the current target");
+	}
+
       if (flag_verbose_asm)
 	{
 	  print_version (asm_out_file, ASM_COMMENT_START, true);
@@ -2049,9 +2060,14 @@ finalize (bool no_backend)
 
   /* Close non-debugging input and output files.  Take special care to note
      whether fclose returns an error, since the pages might still be on the
-     buffer chain while the file is open.  */
+     buffer chain while the file is open.  If the calculation of the GitBOM
+     information is enabled, do not close the asm_out_file because the gitoid
+     of the resulting object file is to be written in the .bom section later,
+     when calculating dependencies for the object file.  */
 
-  if (asm_out_file)
+  if (asm_out_file
+      && !(flag_record_gitbom || str_record_gitbom
+           || (getenv ("GITBOM_DIR") && strlen (getenv ("GITBOM_DIR")) > 0)))
     {
       if (ferror (asm_out_file) != 0)
 	fatal_error (input_location, "error writing to %s: %m", asm_file_name);

--- a/gcc-11.3.0/gcc/toplev.c
+++ b/gcc-11.3.0/gcc/toplev.c
@@ -2062,7 +2062,7 @@ finalize (bool no_backend)
      whether fclose returns an error, since the pages might still be on the
      buffer chain while the file is open.  If the calculation of the GitBOM
      information is enabled, do not close the asm_out_file because the gitoid
-     of the resulting object file is to be written in the .bom section later,
+     of the resulting gitbom file is to be written in the .bom section later,
      when calculating dependencies for the object file.  */
 
   if (asm_out_file

--- a/gcc-11.3.0/gcc/varasm.c
+++ b/gcc-11.3.0/gcc/varasm.c
@@ -67,6 +67,8 @@ along with GCC; see the file COPYING3.  If not see
 #include "xcoffout.h"		/* Needed for external data declarations.  */
 #endif
 
+#define GITOID_LENGTH 20
+
 /* The (assembler) name of the first globally-visible object output.  */
 extern GTY(()) const char *first_global_object_name;
 extern GTY(()) const char *weak_global_object_name;
@@ -8214,9 +8216,9 @@ elf_record_gitbom_write_gitoid (std::string gitoid)
   switch_to_section (bom_section);
 
   const char *gitoid_array = gitoid.c_str ();
-  char gitoid_array_fin[20];
+  char gitoid_array_fin[GITOID_LENGTH];
   convert_ascii_hex_to_ascii_decimal (gitoid_array, gitoid_array_fin);
-  ASM_OUTPUT_ASCII (asm_out_file, gitoid_array_fin, 20);
+  ASM_OUTPUT_ASCII (asm_out_file, gitoid_array_fin, GITOID_LENGTH);
 
   if (ferror (asm_out_file) != 0)
     fatal_error (input_location, "error writing to %s: %m", asm_file_name);

--- a/gcc-11.3.0/gcc/varasm.c
+++ b/gcc-11.3.0/gcc/varasm.c
@@ -61,6 +61,7 @@ along with GCC; see the file COPYING3.  If not see
 #include "alloc-pool.h"
 #include "toplev.h"
 #include "opts.h"
+#include "gitbom.h"
 
 #ifdef XCOFF_DEBUGGING_INFO
 #include "xcoffout.h"		/* Needed for external data declarations.  */
@@ -139,6 +140,7 @@ section *ctors_section;
 section *dtors_section;
 section *bss_section;
 section *sbss_section;
+section *bom_section;
 
 /* Various forms of common section.  All are guaranteed to be nonnull.  */
 section *tls_comm_section;
@@ -8146,6 +8148,81 @@ elf_record_gcc_switches (const char *options)
 			      | SECTION_STRINGS | (SECTION_ENTSIZE & 1), NULL);
   switch_to_section (sec);
   ASM_OUTPUT_ASCII (asm_out_file, options, strlen (options) + 1);
+}
+
+/* This function provides a possible implementation of the
+   TARGET_ASM_RECORD_GITBOM target hook for ELF targets.  When triggered
+   by -frecord-gitbom, it creates a new mergeable, string section in the
+   assembler output file called TARGET_ASM_RECORD_GITBOM_SECTION which
+   contains the gitoid of the GitBOM Document file.  */
+
+void
+elf_record_gitbom (void)
+{
+  bom_section = get_section (targetm.asm_out.record_gitbom_section,
+			     SECTION_WRITE | SECTION_MERGE
+			     | SECTION_STRINGS | (SECTION_ENTSIZE & 1), NULL);
+  switch_to_section (bom_section);
+}
+
+static unsigned char
+get_decimal (unsigned char c)
+{
+  if (c >= 'a' && c <= 'f')
+    c = c - 97 + 10;
+  else if (c >= 'A' && c <= 'F')
+    c = c - 65 + 10;
+  else if (c >= '0' && c <= '9')
+    c -= 48;
+
+  return c;
+}
+
+/* This function converts an input array which has to contain only hex
+   characters into an array with characters that have real decimal
+   values of those hex characters instead of their ASCII values.
+
+   Example: d b 1 4 8
+	element     decimal_value_of_element    decimal_value_of_new_element
+	   d                  100                           13
+	   b                   98                           11
+	   1                   49                            1
+	   4                   52                            4
+	   8                   56                            8                */
+
+static void
+convert_ascii_hex_to_ascii_decimal (const char * in_array, char *out_array)
+{
+  for (unsigned i = 0; i != strlen (in_array) / 2; i++)
+    {
+      unsigned char c1 = in_array[2 * i];
+      unsigned char c2 = in_array[2 * i + 1];
+
+      c1 = get_decimal (c1);
+      c2 = get_decimal (c2);
+
+      out_array[i] = c2 | c1 << 4;
+    }
+}
+
+/* This function puts the gitoid of the GitBOM Document file in
+   the TARGET_ASM_RECORD_GITBOM_SECTION section.  */
+
+void
+elf_record_gitbom_write_gitoid (std::string gitoid)
+{
+  switch_to_section (bom_section);
+
+  const char *gitoid_array = gitoid.c_str ();
+  char gitoid_array_fin[20];
+  convert_ascii_hex_to_ascii_decimal (gitoid_array, gitoid_array_fin);
+  ASM_OUTPUT_ASCII (asm_out_file, gitoid_array_fin, 20);
+
+  if (ferror (asm_out_file) != 0)
+    fatal_error (input_location, "error writing to %s: %m", asm_file_name);
+  if (fclose (asm_out_file) != 0)
+    fatal_error (input_location, "error closing %s: %m", asm_file_name);
+  asm_out_file = NULL;
 }
 
 /* Emit text to declare externally defined symbols. It is needed to

--- a/gcc-11.3.0/libcpp/files.c
+++ b/gcc-11.3.0/libcpp/files.c
@@ -949,12 +949,17 @@ _cpp_stack_file (cpp_reader *pfile, _cpp_file *file, include_type type,
 	sysp = MAX (pfile->buffer->sysp, file->dir->sysp);
 
       /* Add the file to the dependencies on its first inclusion.  */
-      if (CPP_OPTION (pfile, deps.style) > (sysp != 0)
-	  && !file->stack_count
-	  && file->path[0]
-	  && !(pfile->main_file == file
-	       && CPP_OPTION (pfile, deps.ignore_main_file)))
-	deps_add_dep (pfile->deps, file->path);
+      if ((CPP_OPTION (pfile, deps.style) > (sysp != 0)
+           || gitbom_enabled)
+	   && !file->stack_count
+	   && file->path[0]
+	   && !(pfile->main_file == file
+	        && CPP_OPTION (pfile, deps.ignore_main_file)))
+        {
+	  if (!pfile->deps)
+            pfile->deps = deps_init ();
+	  deps_add_dep (pfile->deps, file->path);
+	}
 
       /* Clear buffer_valid since _cpp_clean_line messes it up.  */
       file->buffer_valid = false;

--- a/gcc-11.3.0/libcpp/include/cpplib.h
+++ b/gcc-11.3.0/libcpp/include/cpplib.h
@@ -38,6 +38,12 @@ typedef struct cpp_dir cpp_dir;
 
 struct _cpp_file;
 
+/* Flag which indicates whether the calculation of the GitBOM information
+   is enabled.  */
+extern bool gitbom_enabled;
+
+extern void set_gitbom_enabled (bool);
+
 /* The first three groups, apart from '=', can appear in preprocessor
    expressions (+= and -= are used to indicate unary + and - resp.).
    This allows a lookup table to be implemented in _cpp_parse_expr.

--- a/gcc-11.3.0/libcpp/include/mkdeps.h
+++ b/gcc-11.3.0/libcpp/include/mkdeps.h
@@ -24,6 +24,7 @@ along with this program; see the file COPYING3.  If not see
 #define LIBCPP_MKDEPS_H
 
 #include "cpplib.h"
+#include <string>
 
 /* This is the data structure used by all the functions in mkdeps.c.
    It's quite straightforward, but should be treated as opaque.  */
@@ -67,6 +68,12 @@ extern void deps_add_dep (class mkdeps *, const char *);
 /* Write out a deps buffer to a specified file.  The last argument
    is the number of columns to word-wrap at (0 means don't wrap).  */
 extern void deps_write (const cpp_reader *, FILE *, unsigned int);
+
+/* Write out a deps buffer to the GitBOM Document file in a required
+   format.  Second argument holds the path to a directory in which
+   the GitBOM Document file is to be stored or NULL, if the default
+   location is desired (same location as the object file).  */
+extern std::string deps_write_gitbom (const cpp_reader *, const char *);
 
 /* Write out a deps buffer to a file, in a form that can be read back
    with deps_restore.  Returns nonzero on error, in which case the

--- a/gcc-11.3.0/libcpp/init.c
+++ b/gcc-11.3.0/libcpp/init.c
@@ -176,6 +176,14 @@ init_library (void)
     }
 }
 
+bool gitbom_enabled = false;
+
+void
+set_gitbom_enabled (bool gitbom_flag)
+{
+  gitbom_enabled = gitbom_flag;
+}
+
 /* Initialize a cpp_reader structure.  */
 cpp_reader *
 cpp_create_reader (enum c_lang lang, cpp_hash_table *table,


### PR DESCRIPTION
This PR adds the implementation of the GitBOM concept in the gcc-11.3.0 sources.
It includes:
        1) The creation of the .bom section in the resulting object file, when GitBOM calculation is enabled
        2) The creation of the GitBOM Document file in the desired directory, when GitBOM calculation is enabled
        3) The possibility of specifying the directory in which the GitBOM Document will be stored (GITBOM_DIR environment variable, -frecord-gitbom=<arg> option, or the default case which is the -frecord-gitbom option)
        4) Basic tests to ensure the .bom section is created, when the GitBOM calculation is enabled

Signed-off-by: Vojislav Tomasevic <vojislav.tomasevic@syrmia.com>