### PR TITLE
Reorganizing the structure of the '.bom' section to match ELF note section type and renaming it to '.note.gitbom'

### DIFF
--- a/gcc-11.3.0/gcc/target.def
+++ b/gcc-11.3.0/gcc/target.def
@@ -815,7 +815,7 @@ DEFHOOKPOD
  "This is the name of the section that will be created by the example\n\
 ELF implementation of the @code{TARGET_ASM_RECORD_GITBOM} target\n\
 hook.",
- const char *, ".bom")
+ const char *, ".note.gitbom")
 
 /* Output the definition of a section anchor.  */
 DEFHOOK

--- a/gcc-11.3.0/gcc/testsuite/gcc.dg/env_var_record_gitbom.c
+++ b/gcc-11.3.0/gcc/testsuite/gcc.dg/env_var_record_gitbom.c
@@ -1,5 +1,5 @@
-/* Test whether .bom section is created when environment variable GITBOM_DIR
-   is set. Note that the GitBOM Document file is also created in
+/* Test whether .note.gitbom section is created when environment variable
+   GITBOM_DIR is set. Note that the GitBOM Document file is also created in
    $GITBOM_DIR/.gitbom/objects/<dir>/ inside the gcc/testsuite/gcc directory,
    where <dir> consists of the first two hex characters of the 40-character
    gitoid of that file. The remaining 38 hex characters of that gitoid are
@@ -16,5 +16,16 @@ int f()
   return var;
 }
 
-/* { dg-final { scan-assembler "\t.section\t.bom" } } */
+/* { dg-final { scan-assembler "\t.section\t.note.gitbom" } } */
+/* { dg-final { scan-assembler "\t.string\t\"\\\\007\"" } } */
+/* { dg-final { scan-assembler "\t.string\t\"\"" } } */
+/* { dg-final { scan-assembler "\t.string\t\"\"" } } */
+/* { dg-final { scan-assembler "\t.string\t\"\\\\024\"" } } */
+/* { dg-final { scan-assembler "\t.string\t\"\"" } } */
+/* { dg-final { scan-assembler "\t.string\t\"\"" } } */
+/* { dg-final { scan-assembler "\t.string\t\"\\\\001\"" } } */
+/* { dg-final { scan-assembler "\t.string\t\"\"" } } */
+/* { dg-final { scan-assembler "\t.string\t\"\"" } } */
+/* { dg-final { scan-assembler "\t.string\t\"GITBOM\"" } } */
+/* { dg-final { scan-assembler "\t.string\t\"\"" } } */
 /* { dg-final { scan-assembler "\t.ascii\t\"*\"" } } */

--- a/gcc-11.3.0/gcc/testsuite/gcc.dg/frecord-gitbom.c
+++ b/gcc-11.3.0/gcc/testsuite/gcc.dg/frecord-gitbom.c
@@ -1,4 +1,4 @@
-/* Test whether .bom section is created when -frecord-gitbom=<arg> option is passed.
+/* Test whether .note.gitbom section is created when -frecord-gitbom=<arg> option is passed.
    Note that the GitBOM Document file is also created in <arg>/.gitbom/objects/<dir>/
    inside the gcc/testsuite/gcc directory, where <dir> consists of the first two
    hex characters of the 40-character gitoid of that file. The remaining 38 hex
@@ -15,5 +15,16 @@ int f()
   return var;
 }
 
-/* { dg-final { scan-assembler "\t.section\t.bom" } } */
+/* { dg-final { scan-assembler "\t.section\t.note.gitbom" } } */
+/* { dg-final { scan-assembler "\t.string\t\"\\\\007\"" } } */
+/* { dg-final { scan-assembler "\t.string\t\"\"" } } */
+/* { dg-final { scan-assembler "\t.string\t\"\"" } } */
+/* { dg-final { scan-assembler "\t.string\t\"\\\\024\"" } } */
+/* { dg-final { scan-assembler "\t.string\t\"\"" } } */
+/* { dg-final { scan-assembler "\t.string\t\"\"" } } */
+/* { dg-final { scan-assembler "\t.string\t\"\\\\001\"" } } */
+/* { dg-final { scan-assembler "\t.string\t\"\"" } } */
+/* { dg-final { scan-assembler "\t.string\t\"\"" } } */
+/* { dg-final { scan-assembler "\t.string\t\"GITBOM\"" } } */
+/* { dg-final { scan-assembler "\t.string\t\"\"" } } */
 /* { dg-final { scan-assembler "\t.ascii\t\"*\"" } } */

--- a/gcc-11.3.0/gcc/testsuite/gcc.dg/gitbom.c
+++ b/gcc-11.3.0/gcc/testsuite/gcc.dg/gitbom.c
@@ -1,4 +1,4 @@
-/* Test whether .bom section is created when -frecord-gitbom option is passed.
+/* Test whether .note.gitbom section is created when -frecord-gitbom option is passed.
    Note that the GitBOM Document file is also created in .gitbom/objects/<dir>/
    inside the gcc/testsuite/gcc directory, where <dir> consists of the first two
    hex characters of the 40-character gitoid of that file. The remaining 38 hex
@@ -15,5 +15,16 @@ int f()
   return var;
 }
 
-/* { dg-final { scan-assembler "\t.section\t.bom" } } */
+/* { dg-final { scan-assembler "\t.section\t.note.gitbom" } } */
+/* { dg-final { scan-assembler "\t.string\t\"\\\\007\"" } } */
+/* { dg-final { scan-assembler "\t.string\t\"\"" } } */
+/* { dg-final { scan-assembler "\t.string\t\"\"" } } */
+/* { dg-final { scan-assembler "\t.string\t\"\\\\024\"" } } */
+/* { dg-final { scan-assembler "\t.string\t\"\"" } } */
+/* { dg-final { scan-assembler "\t.string\t\"\"" } } */
+/* { dg-final { scan-assembler "\t.string\t\"\\\\001\"" } } */
+/* { dg-final { scan-assembler "\t.string\t\"\"" } } */
+/* { dg-final { scan-assembler "\t.string\t\"\"" } } */
+/* { dg-final { scan-assembler "\t.string\t\"GITBOM\"" } } */
+/* { dg-final { scan-assembler "\t.string\t\"\"" } } */
 /* { dg-final { scan-assembler "\t.ascii\t\"*\"" } } */

--- a/gcc-11.3.0/gcc/toplev.c
+++ b/gcc-11.3.0/gcc/toplev.c
@@ -2062,8 +2062,8 @@ finalize (bool no_backend)
      whether fclose returns an error, since the pages might still be on the
      buffer chain while the file is open.  If the calculation of the GitBOM
      information is enabled, do not close the asm_out_file because the gitoid
-     of the resulting gitbom file is to be written in the .bom section later,
-     when calculating dependencies for the object file.  */
+     of the resulting gitbom file is to be written in the .note.gitbom section
+     later, when calculating dependencies for the object file.  */
 
   if (asm_out_file
       && !(flag_record_gitbom || str_record_gitbom

--- a/gcc-11.3.0/gcc/varasm.c
+++ b/gcc-11.3.0/gcc/varasm.c
@@ -8193,7 +8193,7 @@ get_decimal (unsigned char c)
 	   8                   56                            8                */
 
 static void
-convert_ascii_hex_to_ascii_decimal (const char * in_array, char *out_array)
+convert_ascii_hex_to_ascii_decimal (const char *in_array, char *out_array)
 {
   for (unsigned i = 0; i != strlen (in_array) / 2; i++)
     {
@@ -8215,9 +8215,31 @@ elf_record_gitbom_write_gitoid (std::string gitoid)
 {
   switch_to_section (bom_section);
 
+  char buff_for_owner_size[4];
+  char buff_for_data_size[4];
+  char buff_for_desc[4];
+  char buff_for_owner[8];
+  buff_for_owner_size[0] = sizeof "GITBOM";
+  buff_for_data_size[0] = GITOID_LENGTH;
+  /* NT_GITBOM_SHA1 has a value 1.  */
+  buff_for_desc[0] = 1;
+  for (unsigned i = 1; i < 4; i++)
+    {
+      buff_for_owner_size[i] = '\0';
+      buff_for_data_size[i] = '\0';
+      buff_for_desc[i] = '\0';
+    }
+  sprintf (buff_for_owner, "%s", "GITBOM");
+  buff_for_owner[7] = '\0';
+
   const char *gitoid_array = gitoid.c_str ();
   char gitoid_array_fin[GITOID_LENGTH];
   convert_ascii_hex_to_ascii_decimal (gitoid_array, gitoid_array_fin);
+
+  ASM_OUTPUT_ASCII (asm_out_file, buff_for_owner_size, 4);
+  ASM_OUTPUT_ASCII (asm_out_file, buff_for_data_size, 4);
+  ASM_OUTPUT_ASCII (asm_out_file, buff_for_desc, 4);
+  ASM_OUTPUT_ASCII (asm_out_file, buff_for_owner, 8);
   ASM_OUTPUT_ASCII (asm_out_file, gitoid_array_fin, GITOID_LENGTH);
 
   if (ferror (asm_out_file) != 0)


### PR DESCRIPTION
This patch introduces two important changes, which are in sync with the approved GitBOM specification:
        1) Section .bom is renamed to .note.gitbom to match the section name in the executable created after linking object files.
        2) The structure of the forementioned section is adjusted to be the same as of the sections which have ELF note section
             type. This is implemented so that it is consistent with the the same section in the executable created after linking object
             files.

Signed-off-by: Vojislav Tomasevic <vojislav.tomasevic@syrmia.com>