### PR TITLE
Adding the support for creating SHA1 and SHA256 symlinks in GitBOM implementation

### DIFF
--- a/gcc-11.3.0/gcc/gcc.c
+++ b/gcc-11.3.0/gcc/gcc.c
@@ -8746,8 +8746,11 @@ driver::main (int argc, char **argv)
      name of the output file is specified with the -o option.  The support
      for creating symlinks in the GitBOM concept when the GitBOM Document
      file gitoid is extracted from the assembly file (when -S option is
-     used) should potentially be implemented as well.  */
-  create_symlinks_gitbom ();
+     used) should potentially be implemented as well.  Call this function
+     only in the NO_EMBED case (when GITBOM_NO_EMBED environment variable
+     is set).  */
+  if (env.get ("GITBOM_NO_EMBED"))
+    create_symlinks_gitbom ();
   maybe_run_linker (argv[0]);
   final_actions ();
   return get_exit_code ();

--- a/gcc-11.3.0/gcc/gcc.h
+++ b/gcc-11.3.0/gcc/gcc.h
@@ -49,6 +49,7 @@ class driver
   int maybe_print_and_exit () const;
   bool prepare_infiles ();
   void do_spec_on_infiles () const;
+  void create_symlinks_gitbom () const;
   void maybe_run_linker (const char *argv0) const;
   void final_actions () const;
   void detect_jobserver () const;

--- a/gcc-11.3.0/gcc/gitbom.h
+++ b/gcc-11.3.0/gcc/gitbom.h
@@ -1,4 +1,9 @@
+#ifndef GCC_GITBOM_H
+#define GCC_GITBOM_H
+
 #include <string>
 
 /* An example implementation for ELF targets.  Defined in varasm.c  */
 extern void elf_record_gitbom_write_gitoid (std::string, std::string);
+
+#endif /* ! GCC_GITBOM_H */


### PR DESCRIPTION
This PR introduces the support for creating both SHA1 and SHA256 GitBOM symlinks in a format:
          (gitoid_of_resulting_object_file -> gitoid_of_gitbom_doc_file)

The symlinks are stored in the .adg directory, which is placed in the same directory where .gitbom directory is also placed. The creation of these symlinks is done whenever the GitBOM information is calculated, but only if -c option is used (indication that compilation is performed) and if -o option is also used (indication that there is a named output object file) when invoking gcc tool.

Signed-off-by: Vojislav Tomasevic <vojislav.tomasevic@syrmia.com>