### PR TITLE
Fixing the issues found while building OpenSSL and Linux kernel

### DIFF
--- a/gcc-11.3.0/gcc/gcc.c
+++ b/gcc-11.3.0/gcc/gcc.c
@@ -49,7 +49,7 @@ compilation is specified by a string called a "spec".  */
 
 #define GITOID_LENGTH_SHA1 20
 #define GITOID_LENGTH_SHA256 32
-#define MAX_LONG_SIZE_STRING_LENGTH 256
+#define MAX_FILE_SIZE_STRING_LENGTH 256
 
 
 
@@ -8157,7 +8157,7 @@ calculate_sha1_omnibor (FILE *dep_file, unsigned char resblock[])
 
   /* This length should be enough for everything up to 64B, which should
      cover long type.  */
-  char buff_for_file_size[MAX_LONG_SIZE_STRING_LENGTH];
+  char buff_for_file_size[MAX_FILE_SIZE_STRING_LENGTH];
   sprintf (buff_for_file_size, "%ld", file_size);
 
   char *init_data = (char *) xcalloc (1, sizeof (char));
@@ -8195,7 +8195,7 @@ calculate_sha256_omnibor (FILE *dep_file, unsigned char resblock[])
 
   /* This length should be enough for everything up to 64B, which should
      cover long type.  */
-  char buff_for_file_size[MAX_LONG_SIZE_STRING_LENGTH];
+  char buff_for_file_size[MAX_FILE_SIZE_STRING_LENGTH];
   sprintf (buff_for_file_size, "%ld", file_size);
 
   char *init_data = (char *) xcalloc (1, sizeof (char));
@@ -8227,6 +8227,12 @@ calculate_sha256_omnibor (FILE *dep_file, unsigned char resblock[])
 void
 get_sha1_gitoid (char **gitoid, FILE *command)
 {
+  /* Each of these arrays should receive a specific line from the
+     output of the readelf tool and 1000 bytes should be enough to
+     cover the entire line (most likely this number could be lower).
+     All 1000 bytes are later copied into these arrays since these
+     lines potentially contain hashes, which could have null
+     terminating characters (therefore, strlen is not satisfactory).  */
   char line[1000], line1[1000], line2[1000];
   int line_cnt = 0;
   bool flag = false;
@@ -8295,6 +8301,12 @@ get_sha1_gitoid (char **gitoid, FILE *command)
 void
 get_sha256_gitoid (char **gitoid, FILE *command)
 {
+  /* Each of these arrays should receive a specific line from the
+     output of the readelf tool and 1000 bytes should be enough to
+     cover the entire line (most likely this number could be lower).
+     All 1000 bytes are later copied into these arrays since these
+     lines potentially contain hashes, which could have null
+     terminating characters (therefore, strlen is not satisfactory).  */
   char line[1000], line1[1000], line2[1000], line3[1000];
   int line_cnt = 0;
   bool flag = false;

--- a/gcc-11.3.0/gcc/gcc.c
+++ b/gcc-11.3.0/gcc/gcc.c
@@ -49,6 +49,7 @@ compilation is specified by a string called a "spec".  */
 
 #define GITOID_LENGTH_SHA1 20
 #define GITOID_LENGTH_SHA256 32
+#define MAX_LONG_SIZE_STRING_LENGTH 256
 
 
 
@@ -8015,7 +8016,8 @@ omnibor_append_to_string (char **str1, const char *str2,
 {
   *str1 = (char *) xrealloc
 	(*str1, sizeof (char) * (len1 + len2 + 1));
-  strcat (*str1, str2);
+  memcpy (*str1 + len1, str2, len2);
+  (*str1)[len1 + len2] = '\0';
 }
 
 /* Set the string str1 to have the contents of the string str2.  */
@@ -8025,7 +8027,8 @@ omnibor_set_contents (char **str1, const char *str2, unsigned long len)
 {
   *str1 = (char *) xrealloc
 	(*str1, sizeof (char) * (len + 1));
-  strcpy (*str1, str2);
+  memcpy (*str1, str2, len);
+  (*str1)[len] = '\0';
 }
 
 /* Return the position of the first occurrence after start_pos position
@@ -8068,7 +8071,7 @@ omnibor_substr (char **str1, unsigned start, unsigned len,
     {
       *str1 = (char *) xrealloc
 	(*str1, sizeof (char) * (len + 1));
-      strncpy (*str1, str2 + start, len);
+      memcpy (*str1, str2 + start, len);
       (*str1)[len] = '\0';
     }
 }
@@ -8154,7 +8157,7 @@ calculate_sha1_omnibor (FILE *dep_file, unsigned char resblock[])
 
   /* This length should be enough for everything up to 64B, which should
      cover long type.  */
-  char buff_for_file_size[200];
+  char buff_for_file_size[MAX_LONG_SIZE_STRING_LENGTH];
   sprintf (buff_for_file_size, "%ld", file_size);
 
   char *init_data = (char *) xcalloc (1, sizeof (char));
@@ -8192,7 +8195,7 @@ calculate_sha256_omnibor (FILE *dep_file, unsigned char resblock[])
 
   /* This length should be enough for everything up to 64B, which should
      cover long type.  */
-  char buff_for_file_size[200];
+  char buff_for_file_size[MAX_LONG_SIZE_STRING_LENGTH];
   sprintf (buff_for_file_size, "%ld", file_size);
 
   char *init_data = (char *) xcalloc (1, sizeof (char));
@@ -8233,10 +8236,10 @@ get_sha1_gitoid (char **gitoid, FILE *command)
 	{
 	  ++line_cnt;
 	  if (line_cnt == 2)
-	    strcpy (line1, line);
+	    memcpy (line1, line, 1000);
 	  else if (line_cnt == 3)
 	    {
-	      strcpy (line2, line);
+	      memcpy (line2, line, 1000);
 	      break;
 	    }
 	}
@@ -8301,12 +8304,12 @@ get_sha256_gitoid (char **gitoid, FILE *command)
 	{
 	  ++line_cnt;
 	  if (line_cnt == 4)
-	    strcpy (line1, line);
+	    memcpy (line1, line, 1000);
 	  else if (line_cnt == 5)
-	    strcpy (line2, line);
+	    memcpy (line2, line, 1000);
 	  else if (line_cnt == 6)
 	    {
-	      strcpy (line3, line);
+	      memcpy (line3, line, 1000);
 	      break;
 	    }
 	}

--- a/gcc-11.3.0/gcc/varasm.c
+++ b/gcc-11.3.0/gcc/varasm.c
@@ -8216,6 +8216,8 @@ void
 elf_record_omnibor_write_gitoid (std::string gitoid_sha1,
 				 std::string gitoid_sha256)
 {
+  if (omnibor_section == NULL)
+    return;
   switch_to_section (omnibor_section);
 
   char buff_for_owner_size[4];

--- a/gcc-11.3.0/libcpp/mkdeps.c
+++ b/gcc-11.3.0/libcpp/mkdeps.c
@@ -32,6 +32,7 @@ along with this program; see the file COPYING3.  If not see
 
 #define GITOID_LENGTH_SHA1 20
 #define GITOID_LENGTH_SHA256 32
+#define MAX_LONG_SIZE_STRING_LENGTH 256
 
 /* Not set up to just include std::vector et al, here's a simple
    implementation.  */
@@ -600,12 +601,13 @@ calculate_sha1_omnibor (FILE* dep_file, unsigned char resblock[])
   fseek (dep_file, 0L, SEEK_END);
   long file_size = ftell (dep_file);
   fseek (dep_file, 0L, SEEK_SET);
-  char buff_for_file_size[sizeof (long)];
+  char buff_for_file_size[MAX_LONG_SIZE_STRING_LENGTH];
   sprintf (buff_for_file_size, "%ld", file_size);
 
   std::string init_data = "blob " + std::to_string (file_size) + '\0';
   char *init_data_char_array = new char [init_data.length () + 1];
-  strcpy (init_data_char_array, init_data.c_str ());
+  memcpy (init_data_char_array, init_data.c_str (), init_data.length ());
+  init_data_char_array[init_data.length()] = '\0';
 
   char *file_contents = new char [file_size];
   fread (file_contents, 1, file_size, dep_file);
@@ -631,15 +633,17 @@ calculate_sha1_omnibor_with_contents (std::string contents,
 				      unsigned char resblock[])
 {
   long file_size = contents.length ();
-  char buff_for_file_size[sizeof(long)];
+  char buff_for_file_size[MAX_LONG_SIZE_STRING_LENGTH];
   sprintf (buff_for_file_size, "%ld", file_size);
 
   std::string init_data = "blob " + std::to_string (file_size) + '\0';
   char *init_data_char_array = new char [init_data.length () + 1];
-  strcpy (init_data_char_array, init_data. c_str ());
+  memcpy (init_data_char_array, init_data.c_str (), init_data.length ());
+  init_data_char_array[init_data.length()] = '\0';
 
   char *file_contents = new char [contents.length () + 1];
-  strcpy (file_contents, contents.c_str ());
+  memcpy (file_contents, contents.c_str (), contents.length ());
+  file_contents[contents.length()] = '\0';
 
   /* Calculate the hash.  */
   struct sha1_ctx ctx;
@@ -663,12 +667,13 @@ calculate_sha256_omnibor (FILE* dep_file, unsigned char resblock[])
   fseek (dep_file, 0L, SEEK_END);
   long file_size = ftell (dep_file);
   fseek (dep_file, 0L, SEEK_SET);
-  char buff_for_file_size[sizeof (long)];
+  char buff_for_file_size[MAX_LONG_SIZE_STRING_LENGTH];
   sprintf (buff_for_file_size, "%ld", file_size);
 
   std::string init_data = "blob " + std::to_string (file_size) + '\0';
   char *init_data_char_array = new char [init_data.length () + 1];
-  strcpy (init_data_char_array, init_data.c_str ());
+  memcpy (init_data_char_array, init_data.c_str (), init_data.length ());
+  init_data_char_array[init_data.length()] = '\0';
 
   char *file_contents = new char [file_size];
   fread (file_contents, 1, file_size, dep_file);
@@ -694,15 +699,17 @@ calculate_sha256_omnibor_with_contents (std::string contents,
 					unsigned char resblock[])
 {
   long file_size = contents.length ();
-  char buff_for_file_size[sizeof(long)];
+  char buff_for_file_size[MAX_LONG_SIZE_STRING_LENGTH];
   sprintf (buff_for_file_size, "%ld", file_size);
 
   std::string init_data = "blob " + std::to_string (file_size) + '\0';
   char *init_data_char_array = new char [init_data.length () + 1];
-  strcpy (init_data_char_array, init_data. c_str ());
+  memcpy (init_data_char_array, init_data.c_str (), init_data.length ());
+  init_data_char_array[init_data.length()] = '\0';
 
   char *file_contents = new char [contents.length () + 1];
-  strcpy (file_contents, contents.c_str ());
+  memcpy (file_contents, contents.c_str (), contents.length ());
+  file_contents[contents.length()] = '\0';
 
   /* Calculate the hash.  */
   struct sha256_ctx ctx;

--- a/gcc-11.3.0/libcpp/mkdeps.c
+++ b/gcc-11.3.0/libcpp/mkdeps.c
@@ -32,7 +32,7 @@ along with this program; see the file COPYING3.  If not see
 
 #define GITOID_LENGTH_SHA1 20
 #define GITOID_LENGTH_SHA256 32
-#define MAX_LONG_SIZE_STRING_LENGTH 256
+#define MAX_FILE_SIZE_STRING_LENGTH 256
 
 /* Not set up to just include std::vector et al, here's a simple
    implementation.  */
@@ -601,7 +601,7 @@ calculate_sha1_omnibor (FILE* dep_file, unsigned char resblock[])
   fseek (dep_file, 0L, SEEK_END);
   long file_size = ftell (dep_file);
   fseek (dep_file, 0L, SEEK_SET);
-  char buff_for_file_size[MAX_LONG_SIZE_STRING_LENGTH];
+  char buff_for_file_size[MAX_FILE_SIZE_STRING_LENGTH];
   sprintf (buff_for_file_size, "%ld", file_size);
 
   std::string init_data = "blob " + std::to_string (file_size) + '\0';
@@ -633,7 +633,7 @@ calculate_sha1_omnibor_with_contents (std::string contents,
 				      unsigned char resblock[])
 {
   long file_size = contents.length ();
-  char buff_for_file_size[MAX_LONG_SIZE_STRING_LENGTH];
+  char buff_for_file_size[MAX_FILE_SIZE_STRING_LENGTH];
   sprintf (buff_for_file_size, "%ld", file_size);
 
   std::string init_data = "blob " + std::to_string (file_size) + '\0';
@@ -667,7 +667,7 @@ calculate_sha256_omnibor (FILE* dep_file, unsigned char resblock[])
   fseek (dep_file, 0L, SEEK_END);
   long file_size = ftell (dep_file);
   fseek (dep_file, 0L, SEEK_SET);
-  char buff_for_file_size[MAX_LONG_SIZE_STRING_LENGTH];
+  char buff_for_file_size[MAX_FILE_SIZE_STRING_LENGTH];
   sprintf (buff_for_file_size, "%ld", file_size);
 
   std::string init_data = "blob " + std::to_string (file_size) + '\0';
@@ -699,7 +699,7 @@ calculate_sha256_omnibor_with_contents (std::string contents,
 					unsigned char resblock[])
 {
   long file_size = contents.length ();
-  char buff_for_file_size[MAX_LONG_SIZE_STRING_LENGTH];
+  char buff_for_file_size[MAX_FILE_SIZE_STRING_LENGTH];
   sprintf (buff_for_file_size, "%ld", file_size);
 
   std::string init_data = "blob " + std::to_string (file_size) + '\0';


### PR DESCRIPTION
This PR fixes the issues which were found while using these OmniBOR-enabled GCC sources to build the OpenSSL project and Linux kernel. The issues were:
                    1) There was a crash when doing only preprocessing, while the OmniBOR information generation was enabled. It is fixed by adding a check whether the omnibor_section variable is not NULL before using it to store OmniBOR information inside the '.note.omnibor' section.
                    2) The usage of strcpy/strncpy/strcat is replaced with the usage of memcpy, since it does not look for null terminating characters (there was an issue where gitoids contained null terminating characters in the middle of them).
                    3) The length of the buff_for_file_size array was insufficient for some files with larger size, so that was adjusted.