### PR TITLE
Fixing the invalid OmniBOR directory case

### DIFF
--- a/gcc-11.3.0/gcc/c-family/c-opts.c
+++ b/gcc-11.3.0/gcc/c-family/c-opts.c
@@ -1369,6 +1369,9 @@ c_common_finish (void)
         }
       if (gitoid_sha1 != "" && gitoid_sha256 != "")
 	elf_record_omnibor_write_gitoid (gitoid_sha1, gitoid_sha256);
+      else
+	fatal_error (input_location,
+		     "Error in creation of OmniBOR Document files");
     }
 
   /* For performance, avoid tearing down cpplib's internal structures

--- a/gcc-11.3.0/gcc/gcc.c
+++ b/gcc-11.3.0/gcc/gcc.c
@@ -8521,6 +8521,13 @@ create_sha1_symlink (int is_omnibor_option_enabled, char *option_dir)
   low_ch[1] = '\0';
 
   FILE *file_executable = fopen (output_file, "rb");
+  if (file_executable == NULL)
+    {
+      free (low_ch);
+      free (high_ch);
+      free (gitoid_exec_sha1);
+      return;
+    }
   unsigned char resblock[GITOID_LENGTH_SHA1];
 
   calculate_sha1_omnibor (file_executable, resblock);
@@ -8612,6 +8619,13 @@ create_sha256_symlink (int is_omnibor_option_enabled, char *option_dir)
   low_ch[1] = '\0';
 
   FILE *file_executable = fopen (output_file, "rb");
+  if (file_executable == NULL)
+    {
+      free (low_ch);
+      free (high_ch);
+      free (gitoid_exec_sha256);
+      return;
+    }
   unsigned char resblock[GITOID_LENGTH_SHA256];
 
   calculate_sha256_omnibor (file_executable, resblock);


### PR DESCRIPTION
This PR contains the changes which fix the issue of creating an empty '.note.omnibor' section when the path to the directory in which the OmniBOR information is to be stored is invalid (now a fatal error is raised from within GCC).